### PR TITLE
Fix Vercel build errors: PDF.js worker path, Json type, UserSetting p…

### DIFF
--- a/src/lib/pdfjs-worker.ts
+++ b/src/lib/pdfjs-worker.ts
@@ -2,7 +2,7 @@ import * as pdfjsLib from "pdfjs-dist";
 
 // Initialize the worker
 if (typeof window !== "undefined") {
-  pdfjsLib.GlobalWorkerOptions.workerSrc = pdfjsLib;
+  pdfjsLib.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjsLib.version}/pdf.worker.min.js`;
 }
 
 export default pdfjsLib;

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,5 +1,5 @@
 import { createClient } from "@supabase/supabase-js";
-import type { Database } from "../types/supabase";
+import type { Database, Json } from "../types/supabase";
 import { sendAnalysisEmail } from "./email";
 import type { GroqMessage } from "./groq";
 

--- a/src/pages/DocumentLibrary.tsx
+++ b/src/pages/DocumentLibrary.tsx
@@ -107,8 +107,7 @@ export default function DocumentLibrary() {
         tags: [doc.metadata.type],
         lastModified: doc.created_at,
         status: "complete" as const,
-        // Fix this to allow high as a valid risk level by setting a default value
-        riskLevel: ("low" as "low" | "medium" | "high"),
+        riskLevel: "low" as "low" | "medium" | "high",
         content: doc.content,
         metadata: doc.metadata,
       }));
@@ -121,8 +120,7 @@ export default function DocumentLibrary() {
       );
       setStats({
         totalDocuments: formattedDocs.length,
-        // This fixes the type error by using the same type for comparison
-        highRiskCount: formattedDocs.filter((doc) => doc.riskLevel === "high" as const)
+        highRiskCount: formattedDocs.filter((doc) => doc.riskLevel === ("high" as const))
           .length,
         categoryCount: uniqueCategories.size,
         analyzedCount: formattedDocs.filter((doc) => doc.status === "complete")

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1,3 +1,6 @@
+// Add JSON type alias to fix 'Cannot find name Json' error
+export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
+
 export interface ProcessedDocument {
   id: string;
   user_id: string;
@@ -61,6 +64,10 @@ export interface UserProfile {
 export interface UserSetting {
   id: string;
   user_id: string;
+  email_notifications: boolean;
+  notification_frequency: string;
+  theme: string;
+  language: string;
   setting_key: string;
   setting_value: any;
   created_at: string;

--- a/src/workers/pdf.worker.ts
+++ b/src/workers/pdf.worker.ts
@@ -1,4 +1,4 @@
 import * as pdfjsLib from "pdfjs-dist";
 
 // Initialize the worker
-pdfjsLib.GlobalWorkerOptions.workerSrc = pdfjsLib;
+pdfjsLib.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjsLib.version}/pdf.worker.min.js`;


### PR DESCRIPTION
## Fixed the vercel build errors:

### PDF.js Worker Path Issues (2 files):
- Updated src/lib/pdfjs-worker.ts and src/workers/pdf.worker.ts to use the correct CDN path for the worker rather than trying to use the library itself as the worker
### Json Type Error:
- Added the missing Json type definition to src/types/supabase.ts which is used for database interactions
### UserSetting Properties:
- Added the missing properties to the UserSetting interface in src/types/supabase.ts:
`email_notifications`
`notification_frequency`
`theme`
`language`
### Type Comparison Issue:
Fixed the type comparison issue in src/pages/DocumentLibrary.tsx by properly using type assertions